### PR TITLE
Add concept evaluation and task stubs for style-aware LMS

### DIFF
--- a/ai_driven_style_aware_lms_concept_evaluation.md
+++ b/ai_driven_style_aware_lms_concept_evaluation.md
@@ -1,0 +1,69 @@
+# AI-Driven, Style-Aware LMS Concept Evaluation
+
+This document evaluates the feasibility of adapting the current DeepSite system to the style-aware learning management system (LMS) envisioned in `ai_driven_style_aware_lms_concept_paper_v_0.md` and outlines implementation tasks to bridge existing gaps.
+
+## Evaluation
+
+DeepSite already has a dynamic content layer that hydrates HTML placeholders using a client-side script that calls Pollinations for text, matching the concept’s “dynamic placeholder” renderer.
+
+Its design-style infrastructure defines named style manifests (e.g., Excalidraw, Material Design) with prompt guidance and icons, allowing users to switch visual skins in a manner similar to the concept’s style manifests.
+
+The project also documents a broad feature set for AI-driven generation and styling, including a “GenerateText.js” system and consistent design guidelines that could support style-aware rendering.
+
+However, the concept paper envisions additional capabilities not present in the current codebase: an “Asset Card” content rack for ingestion and research, a planner that proposes fragment-level diffs, cohort-aware caching with bandit-driven variant selection, assessment hooks with learner modeling, and provenance tracking for auditability. These pieces would need to be added to transform DeepSite into the style-aware LMS described.
+
+## Task Stubs
+
+**Gap: No content rack ingestion or research mode**  
+The concept expects uploads to be normalized into Asset Cards with rights, summaries, tags, and embeddings, plus a Research Mode for acceptance workflow.
+
+:::task-stub{title="Implement content-rack ingestion and research mode"}
+1. Add a `lib/content-rack.ts` module defining `AssetCard` and storage interactions (MongoDB or similar).
+2. Create `components/research-mode` UI to upload PPT/PDF/DOCX, normalize into Asset Cards, and present accept/reject controls.
+3. Integrate OCR and vectorization pipelines (e.g., calling external services) during ingestion; store summaries and tags for later retrieval.
+4. Persist accepted assets in a “rack” collection and expose an API for planner queries.
+:::
+
+**Gap: No lesson planner or plan-diff workflow**  
+The planner is meant to convert objectives into versioned lesson blueprints with acceptance checks and diff-based updates.
+
+:::task-stub{title="Add lesson planner with plan-diff review"}
+1. Introduce `lib/planner.ts` to assemble lesson blueprints from Asset Cards, producing structured blocks with acceptance checks.
+2. Store plan versions in a `lessons` collection; create `components/planner-review` to display proposed diffs for human approval.
+3. Implement APIs to merge approved diffs and invalidate affected fragments for regeneration.
+:::
+
+**Gap: No cohort-aware rendering, caching, or bandit variant selection**  
+The concept requires cache keys incorporating style and cohort, plus a bandit to choose among variants.
+
+:::task-stub{title="Implement cohort-based caching and bandit selection"}
+1. Extend `public/generatetext.js` to compute cache keys `(lesson, concept, block, style, cohort, seed)` and store generated fragments in IndexedDB or a server-side cache.
+2. Add a `lib/cohort.ts` helper to derive cohort IDs from learner profiles (industry, role, region, language, tone).
+3. Build a lightweight bandit module (ε-greedy or Thompson sampling) in `lib/bandit.ts` that tracks fragment performance metrics and selects variants.
+4. Expose learner “Make it mine” controls in `components/lesson-renderer` to switch styles/cohorts and trigger variant generation.
+:::
+
+**Gap: No assessment hooks or learner modeling**  
+Assessments should include machine-readable grading and feed a learner model for per-concept mastery.
+
+:::task-stub{title="Add assessment blocks with learner model updates"}
+1. Define an `Assessment` schema in `types/lesson.ts` with grading hooks (correct indices, rationales, rubrics).
+2. Create `components/assessment` to render MCQ/short-answer blocks and collect responses.
+3. Implement a basic knowledge-tracing model in `lib/learner-model.ts` that updates mastery probabilities per concept.
+4. Hook assessment results into the planner to adjust difficulty for subsequent blocks.
+:::
+
+**Gap: No provenance or audit trail**  
+The concept demands provenance stubs capturing model, prompts, seed, style, and asset lineage for each fragment.
+
+:::task-stub{title="Integrate provenance tracking and audit view"}
+1. Modify `public/generatetext.js` to record provenance metadata alongside cached fragments (model, styleId, cohortId, prompt, seed).
+2. Create a `lib/provenance.ts` module and attach provenance data to rendered HTML via `data-provenance` attributes.
+3. Build `components/admin/audit-view` to query and display provenance and asset lineage for any fragment.
+4. Provide APIs to retire or replace assets across lessons and trigger planner proposals.
+:::
+
+## Conclusion
+
+DeepSite’s existing dynamic content and style-selection mechanisms form a solid rendering foundation for a style-aware LMS. Implementing the additional modules above would extend the system into the full ingest–plan–render loop envisioned in the concept, enabling style- and cohort-aware learning experiences with provenance and continuous improvement.
+


### PR DESCRIPTION
## Summary
- document feasibility of adapting DeepSite into a style-aware LMS
- outline missing features and provide task stubs for implementation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e9d1fe48320a0d7451fe0e93e51