### PR TITLE
feat: add research mode and content rack

### DIFF
--- a/app/api/rack/ingest/route.ts
+++ b/app/api/rack/ingest/route.ts
@@ -1,0 +1,14 @@
+import { createAssetCardFromFile } from "@/lib/content-rack";
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData();
+  const file = form.get("file") as File | null;
+  const title = (form.get("title") as string) || (file ? file.name : "untitled");
+  if (!file) {
+    return new Response("file required", { status: 400 });
+  }
+  const arrayBuffer = await file.arrayBuffer();
+  const card = await createAssetCardFromFile(Buffer.from(arrayBuffer), title);
+  return Response.json(card);
+}

--- a/app/api/rack/route.ts
+++ b/app/api/rack/route.ts
@@ -1,0 +1,15 @@
+import { saveAssetCard, queryRack } from "@/lib/content-rack";
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q") || undefined;
+  const results = await queryRack(q || undefined);
+  return Response.json(results);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const saved = await saveAssetCard(body);
+  return Response.json(saved);
+}

--- a/components/research-mode/index.tsx
+++ b/components/research-mode/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+
+export interface AssetCard {
+  title: string;
+  text: string;
+  summary: string;
+  tags: string[];
+  vector: number[];
+}
+
+export default function ResearchMode() {
+  const [cards, setCards] = useState<AssetCard[]>([]);
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    for (const file of Array.from(files)) {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("title", file.name);
+      const res = await fetch("/api/rack/ingest", {
+        method: "POST",
+        body: formData,
+      });
+      if (res.ok) {
+        const card = await res.json();
+        setCards((prev) => [...prev, card]);
+      }
+    }
+  };
+
+  const accept = async (card: AssetCard) => {
+    await fetch("/api/rack", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(card),
+    });
+    setCards((prev) => prev.filter((c) => c !== card));
+  };
+
+  const reject = (card: AssetCard) => {
+    setCards((prev) => prev.filter((c) => c !== card));
+  };
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="file"
+        multiple
+        accept=".pdf,.ppt,.pptx,.doc,.docx"
+        onChange={handleUpload}
+        className="block"
+      />
+      <div className="grid gap-4">
+        {cards.map((card, idx) => (
+          <div
+            key={idx}
+            className="border rounded p-4 bg-neutral-900 text-neutral-100"
+          >
+            <h3 className="font-semibold">{card.title}</h3>
+            <p className="text-sm mt-2">{card.summary}</p>
+            <div className="flex gap-2 mt-2 flex-wrap">
+              {card.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-1 bg-neutral-800 rounded text-xs"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button
+                onClick={() => accept(card)}
+                className="px-3 py-1 bg-green-600 rounded"
+              >
+                Accept
+              </button>
+              <button
+                onClick={() => reject(card)}
+                className="px-3 py-1 bg-red-600 rounded"
+              >
+                Reject
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/content-rack.ts
+++ b/lib/content-rack.ts
@@ -1,0 +1,86 @@
+import mongoose from "mongoose";
+import dbConnect from "./mongodb";
+
+export interface AssetCard {
+  _id?: string;
+  title: string;
+  text: string;
+  summary: string;
+  tags: string[];
+  vector: number[];
+  createdAt?: Date;
+}
+
+const AssetCardSchema = new mongoose.Schema<AssetCard>({
+  title: { type: String, required: true },
+  text: String,
+  summary: String,
+  tags: [String],
+  vector: [Number],
+  createdAt: { type: Date, default: Date.now },
+});
+
+AssetCardSchema.index({ summary: "text", tags: "text" });
+
+export const RackModel =
+  mongoose.models.Rack || mongoose.model<AssetCard>("Rack", AssetCardSchema);
+
+export async function ocrDocument(file: Buffer): Promise<string> {
+  if (!process.env.OCR_ENDPOINT) {
+    return "";
+  }
+  const res = await fetch(process.env.OCR_ENDPOINT, {
+    method: "POST",
+    body: file,
+  });
+  const data = await res.json();
+  return data.text || "";
+}
+
+export async function vectorizeText(text: string): Promise<{
+  vector: number[];
+  summary: string;
+  tags: string[];
+}> {
+  if (!process.env.VECTORIZE_ENDPOINT) {
+    return { vector: [], summary: "", tags: [] };
+  }
+  const res = await fetch(process.env.VECTORIZE_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  const data = await res.json();
+  return {
+    vector: data.vector || [],
+    summary: data.summary || "",
+    tags: data.tags || [],
+  };
+}
+
+export async function createAssetCardFromFile(
+  file: Buffer,
+  title: string,
+): Promise<AssetCard> {
+  const text = await ocrDocument(file);
+  const { vector, summary, tags } = await vectorizeText(text);
+  return { title, text, vector, summary, tags };
+}
+
+export async function saveAssetCard(card: AssetCard) {
+  await dbConnect();
+  const doc = new RackModel(card);
+  return doc.save();
+}
+
+export async function queryRack(q?: string) {
+  await dbConnect();
+  if (q) {
+    return RackModel.find({
+      $or: [{ summary: new RegExp(q, "i") }, { tags: q }],
+    })
+      .lean()
+      .exec();
+  }
+  return RackModel.find().lean().exec();
+}


### PR DESCRIPTION
## Summary
- add `content-rack` library with OCR/vectorization hooks and Mongo-backed AssetCard storage
- create research mode component to upload documents and curate asset cards
- expose API routes to ingest files and query or persist rack entries

## Testing
- `npm run lint` *(fails: 'analytics' is assigned a value but never used ...)*
- `npx eslint lib/content-rack.ts components/research-mode/index.tsx app/api/rack/route.ts app/api/rack/ingest/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b97a58c558832082585a2b86c3fcf5